### PR TITLE
Time to use ruby23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM freshbooks/ruby
+FROM freshbooks/ruby23
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Ruby 2.0 is end of life - we have a ruby23 repo - let's use it.